### PR TITLE
Added tab completion for commands/subcommands

### DIFF
--- a/Menus/MainMenu.cs
+++ b/Menus/MainMenu.cs
@@ -66,7 +66,6 @@ namespace SingleDose.Menus
                     Console.WriteLine("");
                     SDConsole.iConsoleLineNum += 2;
                     break;
-                    break;
                 case "SETTINGS":
                     Program.sCurrentMenu = "Settings";
                     int cLineHolder = SDConsole.iConsoleLineNum;

--- a/Menus/SettingsMenu.cs
+++ b/Menus/SettingsMenu.cs
@@ -92,14 +92,12 @@ namespace SingleDose.Menus
                     if (SettingsMenu.UseLogging)
                     {
                         SettingsMenu.UseLogging = false;
-                        Console.WriteLine("  [~] Logging Disabled");
-                        SDConsole.iConsoleLineNum++;
+                        SDConsole.WriteWarning("Logging Disabled");
                     }
                     else if (!SettingsMenu.UseLogging)
                     {
                         SettingsMenu.UseLogging = true;
-                        Console.WriteLine("  [~] Logging Enabled");
-                        SDConsole.iConsoleLineNum++;
+                        SDConsole.WriteSuccess("Logging Enabled");
                     }
                     SDConsole.RefreshConfigPanel();
                     break;
@@ -277,7 +275,8 @@ namespace SingleDose.Menus
                     }
                     else
                     {
-                        SDConsole.Write("       Please enter output directory: ");
+                        SDConsole.Write("Please enter output directory: ");
+                        Console.Write("       > ");
                         SettingsMenu.OutputDirectory = Console.ReadLine();
                         SDConsole.iConsoleLineNum++;
                         SettingsMenu.OutputDirectory = Path.GetFullPath(SettingsMenu.OutputDirectory);
@@ -386,7 +385,7 @@ namespace SingleDose.Menus
                                 SettingsMenu.CompileBinary = true;
                                 SettingsMenu.UseLogging = true;
                                 SettingsMenu.szMemAlloc = "RWX";
-                                SDConsole.WriteSuccess("Default settings restored.");
+                                SDConsole.WriteInfo("Default settings restored.");
                                 SDConsole.RefreshConfigPanel();
                                 break;
                             case "TRIGGER":
@@ -394,8 +393,10 @@ namespace SingleDose.Menus
                                 TriggersMenu.TriggerBody = null;
                                 SDConsole.RefreshConfigPanel();
                                 Console.SetCursorPosition(0, SDConsole.iConsoleLineNum + 1);
-                                SDConsole.WriteSuccess("Triggers have been cleared.");
+                                SDConsole.WriteInfo("Triggers have been cleared.");
                                 break;
+                            case "TRIGGERS":
+                                goto case "TRIGGER";
                             default:
                                 break;
                         }

--- a/Misc/SDConsole.cs
+++ b/Misc/SDConsole.cs
@@ -142,20 +142,7 @@ namespace SingleDose.Misc
             ClearCommandPanel(iStartPrint, iLine);
 
             List<string> AvailableCommands = new List<string>();
-            switch (sMenu)
-            {
-                case "Main":
-                    AvailableCommands.AddRange(new string[] { "settings", "triggers", "build", "describe", "reconfig", "show", "help", "clear", "save", "exit"});
-                    break;
-                case "Settings":
-                    AvailableCommands.AddRange(new string[] { "mode", "output", "triggers", "compile", "version", "memset", "clear", "help", "history", "log", "exit" });
-                    break;
-                case "Triggers":
-                    AvailableCommands.AddRange(new string[] { "use", "reconfig", "settings", "help", "clear", "exit"});
-                    break;
-                default:
-                    break;
-            }
+            AvailableCommands = GetMenuCommands(sMenu).ToList();
 
             Console.SetCursorPosition(iStartPrint, iLine);
 
@@ -343,6 +330,27 @@ namespace SingleDose.Misc
                 }
             }
             return finalString;
+        }
+
+        public static string[] GetMenuCommands(string sMenu)
+        {
+            List<string> AvailableCommands = new List<string>();
+            switch (sMenu)
+            {
+                case "Main":
+                    AvailableCommands.AddRange(new string[] { "settings", "triggers", "build", "describe", "reconfig", "show", "help", "clear", "save", "exit" });
+                    break;
+                case "Settings":
+                    AvailableCommands.AddRange(new string[] { "mode", "output", "triggers", "compile", "version", "memset", "clear", "help", "history", "log", "exit" });
+                    break;
+                case "Triggers":
+                    AvailableCommands.AddRange(new string[] { "use", "reconfig", "settings", "help", "clear", "exit" });
+                    break;
+                default:
+                    break;
+            }
+
+            return AvailableCommands.ToArray();
         }
     }
 }

--- a/Misc/SDTabComplete.cs
+++ b/Misc/SDTabComplete.cs
@@ -1,0 +1,252 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SingleDose.Misc
+{
+    internal class SDTabComplete
+    {
+        public static string UseTabComplete(string szCurrentMenu, List<string> listszCommandHistory)
+        {
+            string szCommand = "";
+            bool bvEnterPressed = false;
+            int iHistoryEntry = listszCommandHistory.Count();
+
+            while (!bvEnterPressed)
+            {
+                Console.SetCursorPosition(0, SDConsole.iConsoleLineNum);
+                Console.Write("[" + szCurrentMenu + "]-> ");
+                Console.Write(szCommand);
+
+                //input will hold the key press by user
+                ConsoleKeyInfo input = Console.ReadKey();
+
+                //Handle the key as necessary
+                switch (input.Key)
+                {
+                    case ConsoleKey.Tab:
+                        #region TabKey
+                        // This will hold the commands/subcommands available
+                        List<string> listszCommands = new List<string>() { };
+
+                        // Commands that have subcommands available
+                        if (szCurrentMenu == "Main")
+                        {
+                            if (szCommand.StartsWith("build ") || szCommand.StartsWith("describe "))
+                            {
+                                listszCommands = Reflect.TechniquesFound.Select(x => x.TechniqueName).ToList();
+                            }
+                            else if (szCommand.StartsWith("show "))
+                            {
+                                listszCommands = new List<string>() { "history", "techniques" };
+                            }
+                            else if (szCommand.StartsWith("clear "))
+                            {
+                                listszCommands = new List<string>() { "triggers", "settings" };
+                            }
+                        }
+                        else if (szCurrentMenu == "Settings")
+                        {
+                            if (szCommand.StartsWith("mode "))
+                            {
+                                listszCommands = new List<string>() { "static", "dynamic", "download" };
+                            }
+                            else if (szCommand.StartsWith("version "))
+                            {
+                                listszCommands = Menus.SettingsMenu.dAvailableCSCVersions.Select(x => x.Key).ToList();
+                                listszCommands.Add("custom");
+                            }
+                            else if (szCommand.StartsWith("memset "))
+                            {
+                                listszCommands = new List<string>() { "RWX", "RW/RX"};
+                            }
+                            else if (szCommand.StartsWith("clear "))
+                            {
+                                listszCommands = new List<string>() { "triggers", "settings" };
+                            }
+                        }
+                        else if (szCurrentMenu == "Triggers")
+                        {
+                            if (szCommand.StartsWith("use "))
+                            {
+                                listszCommands = Reflect.TriggersFound.Select(x => x.TriggerName.ToLower()).ToList();
+                            }
+                        }
+
+                        // Default to the commands that match previously typed keys,
+                        // or start iterating through the menu's commands
+                        if (listszCommands.Count() == 0)
+                        {
+                            if (String.IsNullOrEmpty(szCommand))
+                                listszCommands = SDConsole.GetMenuCommands(szCurrentMenu).ToList();
+                            else
+                                listszCommands = SDTabComplete.GetMatchingItems(szCommand, SDConsole.GetMenuCommands(szCurrentMenu)).ToList();
+                        }
+
+                        // The list is still empty, clear the command line and break
+                        if (listszCommands.Count() == 0)
+                        {
+                            ResetCommandLine(szCommand);
+                            break;
+                        }
+
+                        // We'll use this after getting the substring.
+                        ConsoleKeyInfo SLastKey = new ConsoleKeyInfo();
+
+                        //Actually get the subcommand now based on the supplied string array
+                        if (szCommand.Split().Length < 2)
+                        {
+                            if (!String.IsNullOrEmpty(szCommand.Split()[0]))
+                                listszCommands = GetMatchingItems(szCommand.Split()[0], listszCommands.ToArray()).ToList();
+
+                            szCommand = GetBaseCommand(szCurrentMenu, listszCommands, ref SLastKey);
+                        }
+                        else if (szCommand.Split().Length == 2)
+                        {
+                            if (!String.IsNullOrEmpty(szCommand.Split()[1]))
+                                listszCommands = GetMatchingItems(szCommand.Split()[1], listszCommands.ToArray()).ToList();
+                            szCommand = AppendSubCommand(szCurrentMenu, szCommand, listszCommands, ref SLastKey);
+                        }
+
+                        // Handle the last key that was pressed when inside
+                        // GetBaseCommand() && AppendSubCommand() functions
+                        if (SLastKey.Key == ConsoleKey.Enter)
+                        {
+                            goto case ConsoleKey.Enter;
+                        }
+                        else if (SLastKey.Key == ConsoleKey.Backspace)
+                        {
+                            goto case ConsoleKey.Backspace;
+                        }
+                        else if (SLastKey.KeyChar != '\0')
+                        {
+                            input = SLastKey;
+                            goto default;
+                        }
+
+                        #endregion
+                        break;
+                    case ConsoleKey.Enter:
+                        //Break out of the while loop.
+                        bvEnterPressed = true;
+                        break;
+                    case ConsoleKey.Backspace:
+                        // Check to make sure the string is not empty.
+                        if (!String.IsNullOrEmpty(szCommand))
+                        {
+                            //Clear what was typed
+                            ResetCommandLine(szCommand);
+
+                            //Remove the last char in the command
+                            szCommand = szCommand.Remove(szCommand.Length - 1, 1);
+                        }
+                        break;
+                    case ConsoleKey.UpArrow:
+                        if (listszCommandHistory.Count() != 0 && iHistoryEntry == 0)
+                            iHistoryEntry = listszCommandHistory.Count();
+
+                        if (iHistoryEntry != 0)
+                        {
+                            ResetCommandLine(szCommand);
+                            szCommand = listszCommandHistory[--iHistoryEntry];
+                        }
+                        break;
+                    case ConsoleKey.DownArrow:
+                        if (listszCommandHistory.Count() != 0 && iHistoryEntry == listszCommandHistory.Count())
+                            iHistoryEntry = 0;
+
+                        if (iHistoryEntry != listszCommandHistory.Count())
+                        {
+                            ResetCommandLine(szCommand);
+                            szCommand = listszCommandHistory[iHistoryEntry++];
+                        }
+                        break;
+                    case ConsoleKey.Delete:
+                        break;
+                    case ConsoleKey.LeftArrow:
+                        break;
+                    case ConsoleKey.RightArrow:
+                        break;
+                    default:
+                        szCommand += input.KeyChar.ToString();
+                        break;
+                }
+            }
+
+            return szCommand;
+        }
+
+        public static string GetBaseCommand(string szCurrentMenu, List<string> listszCommands, ref ConsoleKeyInfo SLastKey)
+        {
+            int x = 0;
+            string szCommand = "";
+            
+            if (listszCommands.Count() == 0)
+                return szCommand;
+
+            do
+            {
+                ResetCommandLine(listszCommands[x]);
+                
+                if (SLastKey.Key == ConsoleKey.Tab)
+                    x++;
+
+                if (x >= listszCommands.Count())
+                    x = 0;
+
+                Console.SetCursorPosition(0, SDConsole.iConsoleLineNum);
+                Console.Write("[" + szCurrentMenu + "]-> ");
+                Console.Write(listszCommands[x]);
+            } while ((SLastKey = Console.ReadKey()).Key == ConsoleKey.Tab);
+
+            szCommand = listszCommands[x];
+            return szCommand;
+        }
+
+        public static string AppendSubCommand(string szCurrentMenu, string szCommand, List<string> listszSubCommands, ref ConsoleKeyInfo SLastKey)
+        {
+            // Validation
+            if (listszSubCommands.Count() == 0)
+                return szCommand;
+            // End Validation 
+
+            int x = 0;
+            string szTemp = "";
+            szCommand = szCommand.Split()[0] + " ";
+            do
+            {
+                ResetCommandLine(szCommand + szTemp);
+                szTemp = listszSubCommands[x++];
+
+                Console.SetCursorPosition(0, SDConsole.iConsoleLineNum);
+                Console.Write("[" + szCurrentMenu + "]-> ");
+                Console.Write(szCommand);
+                Console.Write(szTemp);
+
+                if (x >= listszSubCommands.Count())
+                    x = 0;
+            } while ((SLastKey = Console.ReadKey()).Key == ConsoleKey.Tab);
+
+            szCommand = szCommand + szTemp;
+            return szCommand;
+        }
+
+        public static string[] GetMatchingItems(string szInput, string[] arrszCompareArr)
+        {
+            string[] arrszResults = new string[]{};
+            
+            if (szInput != null)
+                arrszResults = arrszCompareArr.Where(x => x.ToLower().StartsWith(szInput.ToLower())).ToArray();
+            else
+                arrszResults = arrszCompareArr;
+
+            return arrszResults;
+        }
+
+        public static void ResetCommandLine(string szCommand)
+        {
+            Console.SetCursorPosition(0, SDConsole.iConsoleLineNum);
+            Console.Write(String.Concat(Enumerable.Repeat(" ", 15 + szCommand.Length).ToArray()));
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,7 @@
 ﻿using SingleDose.Menus;
 using SingleDose.Misc;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace SingleDose
@@ -29,30 +30,43 @@ namespace SingleDose
 
         static void Start()
         {
-            string Command = null;
 
             SDConsole.PrintHeader();
             SDConsole.PrintSettings(Console.WindowWidth - 59, SDConsole.iConsoleLineNum);
             SDConsole.PrintCommandHelp(Console.WindowWidth - 59, SDConsole.iConsoleLineNum+9, sCurrentMenu);
             SDConsole.iConsoleLineNum = 0;
+
+            List<string> CommandHistory = new List<string>();
+
             while (true)
             {
-                Console.SetCursorPosition(0, SDConsole.iConsoleLineNum);
-                Console.Write("["+sCurrentMenu+"]-> ");
-                Command = Console.ReadLine();
-                switch(sCurrentMenu)
+                string Command = null;
+
+                //Getting the command used to just be Console.ReadLine(), but tab complete seems
+                //to need a significant amount of code. So it is being implemented from it's own
+                //dedicated file: SDTabComplete.cs.
+                Command = SDTabComplete.UseTabComplete(sCurrentMenu, CommandHistory);
+
+                if (!String.IsNullOrEmpty(Command))
+                    CommandHistory.Add(Command);
+
+                if (!String.IsNullOrEmpty(Command))
                 {
-                    case "Main":
-                        MainMenu.CommandHandler(Command);
-                        break;
-                    case "Settings":
-                        SettingsMenu.CommandHandler(Command);
-                        break;
-                    case "Triggers":
-                        TriggersMenu.CommandHandler(Command);
-                        break;
-                    default:
-                        break;
+                    Console.SetCursorPosition(0, SDConsole.iConsoleLineNum + 1);
+                    switch (sCurrentMenu)
+                    {
+                        case "Main":
+                            MainMenu.CommandHandler(Command);
+                            break;
+                        case "Settings":
+                            SettingsMenu.CommandHandler(Command);
+                            break;
+                        case "Triggers":
+                            TriggersMenu.CommandHandler(Command);
+                            break;
+                        default:
+                            break;
+                    }
                 }
 
                 SDConsole.iConsoleLineNum++;

--- a/SingleDose.csproj
+++ b/SingleDose.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Misc\MemConfig.cs" />
     <Compile Include="Misc\MiscFuncs.cs" />
     <Compile Include="Misc\SDConsole.cs" />
+    <Compile Include="Misc\SDTabComplete.cs" />
     <Compile Include="Misc\Shellcode.cs" />
     <Compile Include="Misc\Tutorial.cs" />
     <Compile Include="PInvoke\Comdlg32.cs" />


### PR DESCRIPTION
Adds:
- Tab completion for commands/subcommands - including techniques & versions.
**NOTE:** Tab completion was not implemented for the tutorial portion.

Fixes:
- Minor inconsistencies among menus related to messages displayed when changing or clearing settings/triggers